### PR TITLE
patch-dns-hosts-support

### DIFF
--- a/Webinject/MYMETA.json
+++ b/Webinject/MYMETA.json
@@ -40,7 +40,9 @@
             "HTTP::Cookies" : "0",
             "HTTP::Request::Common" : "0",
             "LWP" : "0",
+            "LWP::UserAgent::DNS::Hosts" : "0",
             "Time::HiRes" : "0",
+            "URI" : "0",
             "XML::Parser" : "0",
             "XML::Simple" : "0",
             "perl" : "5.006"

--- a/Webinject/MYMETA.yml
+++ b/Webinject/MYMETA.yml
@@ -26,7 +26,9 @@ requires:
   HTTP::Cookies: 0
   HTTP::Request::Common: 0
   LWP: 0
+  LWP::UserAgent::DNS::Hosts: 0
   Time::HiRes: 0
+  URI: 0
   XML::Parser: 0
   XML::Simple: 0
   perl: 5.006

--- a/Webinject/Makefile.PL
+++ b/Webinject/Makefile.PL
@@ -10,16 +10,18 @@ resources(
     'repository', => 'http://github.com/sni/Webinject',
 );
 
-requires 'LWP'                     => 0;
-requires 'XML::Simple'             => 0;
-requires 'HTTP::Request::Common'   => 0;
-requires 'HTTP::Cookies'           => 0;
-requires 'Time::HiRes'             => 0;
-requires 'Getopt::Long'            => 0;
-requires 'Crypt::SSLeay'           => 0;
-requires 'XML::Parser'             => 0;
-requires 'Error'                   => 0;
-requires 'File::Temp'              => 0;
+requires 'LWP'                          => 0;
+requires 'XML::Simple'                  => 0;
+requires 'HTTP::Request::Common'        => 0;
+requires 'HTTP::Cookies'                => 0;
+requires 'Time::HiRes'                  => 0;
+requires 'Getopt::Long'                 => 0;
+requires 'Crypt::SSLeay'                => 0;
+requires 'XML::Parser'                  => 0;
+requires 'Error'                        => 0;
+requires 'File::Temp'                   => 0;
+requires 'URI'                          => 0;
+requires 'LWP::UserAgent::DNS::Hosts'   => 0;
 
 install_script 'bin/webinject.pl';
 


### PR DESCRIPTION
- added support for a temporary overwrite of the hosts entry for the baseurl, allowing checking of vhosts behind proxies and realservers behind loadbalancers.
- uses module LWP::UserAgent::DNS::Hosts to change the ip of the target url.
- uses module URI to extract fqdn needed for LWP::UserAgent::DNS::Hosts
- use <realserverip>x.x.x.x</realserverip> in the config.xml to overwrite the dns to target e.g. 127.0.0.1 or the ip of your realserver
