### PR TITLE
patch-realserver-support

### DIFF
--- a/Webinject/MYMETA.json
+++ b/Webinject/MYMETA.json
@@ -41,6 +41,7 @@
             "HTTP::Request::Common" : "0",
             "LWP" : "0",
             "Time::HiRes" : "0",
+            "URI" : "0",
             "XML::Parser" : "0",
             "XML::Simple" : "0",
             "perl" : "5.006"

--- a/Webinject/MYMETA.yml
+++ b/Webinject/MYMETA.yml
@@ -27,6 +27,7 @@ requires:
   HTTP::Request::Common: 0
   LWP: 0
   Time::HiRes: 0
+  URI: 0
   XML::Parser: 0
   XML::Simple: 0
   perl: 5.006

--- a/Webinject/Makefile.PL
+++ b/Webinject/Makefile.PL
@@ -20,6 +20,7 @@ requires 'Crypt::SSLeay'           => 0;
 requires 'XML::Parser'             => 0;
 requires 'Error'                   => 0;
 requires 'File::Temp'              => 0;
+requires 'URI'                     => 0;
 
 install_script 'bin/webinject.pl';
 

--- a/Webinject/lib/Webinject.pm
+++ b/Webinject/lib/Webinject.pm
@@ -20,6 +20,7 @@ use strict;
 use warnings;
 use Carp;
 use LWP;
+use URI;
 use HTTP::Request::Common;
 use HTTP::Cookies;
 use XML::Simple;
@@ -333,6 +334,15 @@ sub _run_test_case {
         $case->{$key} = $self->_convertbackxmlresult($case->{$key});
     }
 
+    # replace host with realserverip in url and add http host header to useragent
+    if($self->{'config'}->{'realserverip'})
+    {
+        my($uri)=URI->new($case->{url});
+        my($host)=$uri->host();
+        $useragent->default_header('Host' => $uri->host());
+        $case->{url}=~s/$host/$self->{'config'}->{'realserverip'}/;
+    }
+
     if( $self->{'gui'} ) { $self->_gui_tc_descript($case); }
 
     push @{$case->{'messages'}}, { 'html' => "<td>" }; # HTML: open table column
@@ -634,6 +644,7 @@ sub _set_defaults {
         'reporttype'                => 'standard',
         'output_dir'                => './',
         'nooutput'                  => undef,
+        'realserverip'              => '',
         'baseurl'                   => '',
         'baseurl1'                  => '',
         'baseurl2'                  => '',
@@ -1318,7 +1329,7 @@ sub _read_config_xml {
     foreach (@configlines) {
 
         for my $key (
-            qw/baseurl baseurl1 baseurl2 gnuplot proxy timeout output_dir
+            qw/realserverip baseurl baseurl1 baseurl2 gnuplot proxy timeout output_dir
             globaltimeout globalhttplog standaloneplot max_redirect
             break_on_errors useragent/
           )
@@ -1495,6 +1506,7 @@ sub _convertbackxml {
     $string =~ s~{AMPERSAND}~&~gmx;
     $string =~ s~{LESSTHAN}~<~gmx;
     $string =~ s~{TIMESTAMP}~$timestamp~gmx;
+    $string =~ s~{REALSERVERIP}~$self->{'config'}->{realserverip}~gmx;
     $string =~ s~{BASEURL}~$self->{'config'}->{baseurl}~gmx;
     $string =~ s~{BASEURL1}~$self->{'config'}->{baseurl1}~gmx;
     $string =~ s~{BASEURL2}~$self->{'config'}->{baseurl2}~gmx;


### PR DESCRIPTION
- added optional realserverip variable to config.xml which will allow direct checking of named vhosts on multiple realservers behind a loadbalancer.
- use <realserverip>x.x.x.x</realserverip> in the config.xml and the host part of the url listed in each test case will be replaced with this ip address, while still sending the host (fqdn) in the http host header
