### PR TITLE
Fix for uninitialized value $val

### DIFF
--- a/Webinject/lib/Webinject.pm
+++ b/Webinject/lib/Webinject.pm
@@ -1594,7 +1594,7 @@ sub _url_escape {
     # LWP handles url encoding already, but use this to escape valid chars that LWP won't convert (like +)
     my @return;
     for my $val (@values) {
-        $val =~ s/[^-\w.,!~'()\/\ ]/uc sprintf "%%%02x", ord $&/egmx;
+        $val =~ s/[^-\w.,!~'()\/\ ]/uc sprintf "%%%02x", ord $&/egmx if defined $val;
         push @return, $val;
     }
     return wantarray ? @return : $return[0];


### PR DESCRIPTION
For for issue #9 "Use of uninitialized value $val in substitution (s///) at /usr/lib/perl5/vendor_perl/5.18.2/Webinject.pm line 1597."
